### PR TITLE
added --exit in npm test + 1 test + coverage package

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -10,8 +10,12 @@
     "moxios": "^0.4.0",
     "nock": "^12.0.3"
   },
-
   "scripts": {
     "test": "mocha test --exit",
+    "coverage": "nyc mocha --exit",
+    "coverage:html": "nyc --reporter=html mocha test --exit"
+  },
+  "devDependencies": {
+    "nyc": "^15.1.0"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,6 @@
   },
 
   "scripts": {
-    "test": "mocha"
+    "test": "mocha test --exit",
   }
 }

--- a/server/test/test.js
+++ b/server/test/test.js
@@ -8,6 +8,22 @@ let nock = require("nock");
 
 chai.use(chaiHttp);
 
+describe('/', () => {
+  describe('/GET /', () => {
+    it('it returns pokemon data when requested', () => {
+      chai
+        .request(server)
+        .get('/')
+        .end((err, res) => {
+          res.should.have.status(200)
+          res.body.results.should.a('array')
+          res.body.results.length.should.be.greater(1)
+          done()
+        })
+    })
+  })
+})
+
 describe("/pokemons", () => {
   describe("/GET /search/:search", () => {
     context("when the pokemon api returns OK", () => {


### PR DESCRIPTION
Fixes npm run test not exiting properly. 

**To reproduce**

1. Git clone the repo.
2. Run `npm i` in server dir.
3. Run `npm run test`

**Expected behavior**

1. After tests are done, exit the process.

**Actual behavior**

1. After tests are done, it hangs and doesn't exit the process.

Also added one test for  `GET` /

Current coverage report

![image](https://user-images.githubusercontent.com/34790214/94978047-274edd80-054e-11eb-8e3a-8668693e9785.png)  